### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/maxstudyaz400/449dd4c5-70c8-491c-9efc-981b620cc481/46a450d7-ab75-4c2e-a7cb-0ca21e17b37c/_apis/work/boardbadge/0af5c09b-e42e-4b8e-8cdb-a7e9d99db83d)](https://dev.azure.com/maxstudyaz400/449dd4c5-70c8-491c-9efc-981b620cc481/_boards/board/t/46a450d7-ab75-4c2e-a7cb-0ca21e17b37c/Microsoft.RequirementCategory)
 # maxstudy-az400
 Repository per studio


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1055. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.